### PR TITLE
Update JDKs in travis configuration and add caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,31 @@
-language: scala
+# Use Docker-based container (instead of OpenVZ)
 sudo: false
+
+language: scala
+
 scala:
   - 2.10.7
-script: 
-  - sbt ++$TRAVIS_SCALA_VERSION test scripted
+
+jdk:
+  - openjdk7
+  - openjdk8
+
+script:
+  - sbt "; clean; test; scripted"
+
+  # Tricks to avoid unnecessary cache updates
+  - find $HOME/.ivy2 -name "ivydata-*.properties" -delete
+  - find $HOME/.sbt -name "*.lock" -delete
+
+cache:
+  directories:
+    - $HOME/.m2
+    - $HOME/.ivy2
+    - $HOME/.sbt/boot/scala-$TRAVIS_SCALA_VERSION
+    - $HOME/.sbt/launchers/0.13.17
+
 notifications:
   email:
     recipients:
       - m.aichler@mediacluster.de
-jdk:
-  - openjdk7
-  - oraclejdk7
+


### PR DESCRIPTION
Replaces oraclejdk7 with openjdk8 and adds caching to the travis build.